### PR TITLE
GH Page: Update index.html to fix typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -244,8 +244,8 @@
           <h2 class="title is-3">Remaining Challenges for STR</h2>
           <div class="content has-text-justified">
             <p>
-              We sumarized seven challenges for STR in real-world scenarios through error analysis on Union14M-L. Details 
-              can be find in our paper
+              We summarized seven challenges for STR in real-world scenarios through error analysis on Union14M-L. Details 
+              can be found in our paper
             </p>
             <p>
             <div align=center>
@@ -271,7 +271,7 @@
       <!-- Abstract. -->
       <div class="columns is-centered has-text-centered">
         <div class="column is-four-fifths">
-          <h2 class="title is-3">Benchmar Experiments</h2>
+          <h2 class="title is-3">Benchmark Experiments</h2>
           <div class="content has-text-justified">
           <p>
             We conducted benchmark tests on the aforementioned 13 STR models using Union14M-L to provide more quantitative analysis


### PR DESCRIPTION
Hi there,

I've come across a few minor typos on your GitHub page that I wanted to point out and suggest corrections for:

1. "sumarized" should be corrected to "summarized."
2. "can be find" should be corrected to "can be found."
3. "benchmar" should be corrected to "benchmark."

I hope these suggestions are helpful in maintaining the quality of your content. 
Additionally, I wanted to extend my congratulations on the outstanding work you've been doing!

Thank you for your time and consideration.
